### PR TITLE
Game challenges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time",
+ "time 0.3.19",
  "url",
 ]
 
@@ -389,6 +389,7 @@ dependencies = [
  "actix-web-actors",
  "alcoholic_jwt",
  "bb8",
+ "chrono",
  "diesel",
  "diesel-async",
  "dotenvy",
@@ -524,9 +525,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
@@ -559,7 +563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time",
+ "time 0.3.19",
  "version_check",
 ]
 
@@ -747,6 +751,7 @@ checksum = "4391a22b19c916e50bec4d6140f29bdda3e3bb187223fe6e3ea0b6e4d1021c04"
 dependencies = [
  "bitflags",
  "byteorder",
+ "chrono",
  "diesel_derives",
  "itoa",
  "pq-sys",
@@ -1011,7 +1016,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1480,7 +1485,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
 ]
 
@@ -2169,7 +2174,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time",
+ "time 0.3.19",
 ]
 
 [[package]]
@@ -2224,7 +2229,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time",
+ "time 0.3.19",
 ]
 
 [[package]]
@@ -2359,6 +2364,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -2635,6 +2651,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,7 @@ dependencies = [
  "diesel_derives",
  "itoa",
  "pq-sys",
+ "uuid",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "*", features = ["derive"] }
 serde_with = "2.2.*"
 jsonwebtoken-google = "0.1.6"
 serde_json = "1.0.*"
-diesel = { version = "2.0.0", features = ["postgres", "chrono"] }
+diesel = { version = "2.0.0", features = ["postgres", "chrono", "uuid"] }
 diesel-async = { version = "0.2.0", features = ["postgres", "bb8"] }
 bb8 = { version = "0.8.0" }
 dotenvy = "0.15"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "*", features = ["derive"] }
 serde_with = "2.2.*"
 jsonwebtoken-google = "0.1.6"
 serde_json = "1.0.*"
-diesel = { version = "2.0.0", features = ["postgres"] }
+diesel = { version = "2.0.0", features = ["postgres", "chrono"] }
 diesel-async = { version = "0.2.0", features = ["postgres", "bb8"] }
 bb8 = { version = "0.8.0" }
 dotenvy = "0.15"
@@ -30,3 +30,4 @@ tokio-stream = "*"
 reqwest = "0.11.14"
 alcoholic_jwt = "4091.0.0"
 thiserror = "1.0.*"
+chrono = { version = "0.4.23", features = ["serde"] }

--- a/backend/diesel.toml
+++ b/backend/diesel.toml
@@ -2,7 +2,7 @@
 # see https://diesel.rs/guides/configuring-diesel-cli
 
 [print_schema]
-file = "src/schema.rs"
+file = "src/db/schema.rs"
 
 [migrations_directory]
 dir = "migrations"

--- a/backend/migrations/2023-03-10-004745_game_challenge/down.sql
+++ b/backend/migrations/2023-03-10-004745_game_challenge/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE game_challenges;

--- a/backend/migrations/2023-03-10-004745_game_challenge/up.sql
+++ b/backend/migrations/2023-03-10-004745_game_challenge/up.sql
@@ -5,5 +5,5 @@ CREATE TABLE game_challenges (
     ranked boolean not null,
     public boolean not null,
     tournament_queen_rule boolean not null,
-    expiration_time timestamp with time zone not null
+    created_at timestamp with time zone not null
 )

--- a/backend/migrations/2023-03-10-004745_game_challenge/up.sql
+++ b/backend/migrations/2023-03-10-004745_game_challenge/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE game_challenges (
+    id serial primary key not null,
+    challenger_uid text references users (uid) not null,
+    game_type text not null,
+    ranked boolean not null,
+    public boolean not null,
+    tournament_queen_rule boolean not null,
+    expiration_time timestamp with time zone not null
+)

--- a/backend/migrations/2023-03-10-004745_game_challenge/up.sql
+++ b/backend/migrations/2023-03-10-004745_game_challenge/up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE game_challenges (
-    id serial primary key not null,
+    id uuid default gen_random_uuid() primary key not null,
     challenger_uid text references users (uid) not null,
     game_type text not null,
     ranked boolean not null,

--- a/backend/src/api/game/challenge.rs
+++ b/backend/src/api/game/challenge.rs
@@ -1,0 +1,62 @@
+use actix_web::{post, web, HttpResponse, delete};
+use hive_lib::game_type::GameType;
+use serde::{Deserialize, Serialize};
+
+use crate::server_error::ServerError;
+use crate::model::challenge::GameChallenge;
+use crate::{db::util::DbPool, extractors::auth::AuthenticatedUser};
+
+#[derive(Deserialize)]
+pub struct NewGameRequest {
+    // Whether this challenge should be listed publicly
+    pub public: bool,
+
+    // Whether the game will be ranked
+    pub ranked: bool,
+
+    // Whether the game follows the "tournament" rules, i.e. the queen
+    // cannot be played first. Always true for now
+    pub tournament_queen_rule: bool,
+
+    pub game_type: GameType,
+}
+
+#[derive(Serialize)]
+pub struct NewGameResponse {
+    challenge_url: String,
+}
+
+#[post("/game/challenge")]
+pub async fn create_game_challenge(
+    game: web::Json<NewGameRequest>,
+    auth_user: AuthenticatedUser,
+    pool: web::Data<DbPool>,
+) -> Result<HttpResponse, ServerError> {
+    let challenge = GameChallenge::create(&auth_user.uid, &game, &pool).await?;
+    let challenge_url = format!("/game/challenge/{}", challenge.id);
+    Ok(HttpResponse::Created().json(NewGameResponse { challenge_url }))
+}
+
+#[post("/game/challenge/{id}/accept")]
+pub async fn accept_game_challenge(
+    id: web::Path<i32>,
+    _auth_user: AuthenticatedUser,
+    pool: web::Data<DbPool>,
+) -> Result<HttpResponse, ServerError> {
+    let _challenge = GameChallenge::get(*id, &pool).await?;
+    // TODO: create a new game between auth_user and the challenger, then
+    // delete the challenge
+    Err(ServerError::Unimplemented)
+}
+
+#[delete("/game/challenge/{id}")]
+pub async fn delete_game_challenge(
+    id: web::Path<i32>,
+    auth_user: AuthenticatedUser,
+    pool: web::Data<DbPool>,
+) -> Result<HttpResponse, ServerError> {
+    let challenge = GameChallenge::get(*id, &pool).await?;
+    auth_user.authorize(&challenge.challenger_uid)?;
+    challenge.delete(&pool).await?;
+    Ok(HttpResponse::NoContent().finish())
+}

--- a/backend/src/api/game/challenge.rs
+++ b/backend/src/api/game/challenge.rs
@@ -16,7 +16,7 @@ pub struct NewChallengeRequest {
     pub ranked: bool,
 
     // Whether the game follows the "tournament" rules, i.e. the queen
-    // cannot be played first. Always true for now
+    // cannot be played first.
     pub tournament_queen_rule: bool,
 
     pub game_type: GameType,

--- a/backend/src/api/game/challenge.rs
+++ b/backend/src/api/game/challenge.rs
@@ -1,13 +1,14 @@
-use actix_web::{post, web, HttpResponse, delete};
+use actix_web::{delete, post, web, HttpResponse};
 use hive_lib::game_type::GameType;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
-use crate::server_error::ServerError;
 use crate::model::challenge::GameChallenge;
+use crate::server_error::ServerError;
 use crate::{db::util::DbPool, extractors::auth::AuthenticatedUser};
 
 #[derive(Deserialize)]
-pub struct NewGameRequest {
+pub struct NewChallengeRequest {
     // Whether this challenge should be listed publicly
     pub public: bool,
 
@@ -22,28 +23,28 @@ pub struct NewGameRequest {
 }
 
 #[derive(Serialize)]
-pub struct NewGameResponse {
+pub struct NewChallengeResponse {
     challenge_url: String,
 }
 
 #[post("/game/challenge")]
 pub async fn create_game_challenge(
-    game: web::Json<NewGameRequest>,
+    game: web::Json<NewChallengeRequest>,
     auth_user: AuthenticatedUser,
     pool: web::Data<DbPool>,
 ) -> Result<HttpResponse, ServerError> {
     let challenge = GameChallenge::create(&auth_user.uid, &game, &pool).await?;
     let challenge_url = format!("/game/challenge/{}", challenge.id);
-    Ok(HttpResponse::Created().json(NewGameResponse { challenge_url }))
+    Ok(HttpResponse::Created().json(NewChallengeResponse { challenge_url }))
 }
 
 #[post("/game/challenge/{id}/accept")]
 pub async fn accept_game_challenge(
-    id: web::Path<i32>,
+    id: web::Path<Uuid>,
     _auth_user: AuthenticatedUser,
     pool: web::Data<DbPool>,
 ) -> Result<HttpResponse, ServerError> {
-    let _challenge = GameChallenge::get(*id, &pool).await?;
+    let _challenge = GameChallenge::get(&id, &pool).await?;
     // TODO: create a new game between auth_user and the challenger, then
     // delete the challenge
     Err(ServerError::Unimplemented)
@@ -51,11 +52,11 @@ pub async fn accept_game_challenge(
 
 #[delete("/game/challenge/{id}")]
 pub async fn delete_game_challenge(
-    id: web::Path<i32>,
+    id: web::Path<Uuid>,
     auth_user: AuthenticatedUser,
     pool: web::Data<DbPool>,
 ) -> Result<HttpResponse, ServerError> {
-    let challenge = GameChallenge::get(*id, &pool).await?;
+    let challenge = GameChallenge::get(&id, &pool).await?;
     auth_user.authorize(&challenge.challenger_uid)?;
     challenge.delete(&pool).await?;
     Ok(HttpResponse::NoContent().finish())

--- a/backend/src/api/game/mod.rs
+++ b/backend/src/api/game/mod.rs
@@ -1,2 +1,2 @@
-pub mod play;
 pub mod challenge;
+pub mod play;

--- a/backend/src/api/game/mod.rs
+++ b/backend/src/api/game/mod.rs
@@ -1,1 +1,2 @@
 pub mod play;
+pub mod challenge;

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -2,7 +2,7 @@
 
 diesel::table! {
     game_challenges (id) {
-        id -> Int4,
+        id -> Uuid,
         challenger_uid -> Text,
         game_type -> Text,
         ranked -> Bool,
@@ -22,7 +22,4 @@ diesel::table! {
 
 diesel::joinable!(game_challenges -> users (challenger_uid));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    game_challenges,
-    users,
-);
+diesel::allow_tables_to_appear_in_same_query!(game_challenges, users,);

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -1,9 +1,28 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    game_challenges (id) {
+        id -> Int4,
+        challenger_uid -> Text,
+        game_type -> Text,
+        ranked -> Bool,
+        public -> Bool,
+        tournament_queen_rule -> Bool,
+        expiration_time -> Timestamptz,
+    }
+}
+
+diesel::table! {
     users (uid) {
         uid -> Text,
         username -> Varchar,
         is_guest -> Bool,
     }
 }
+
+diesel::joinable!(game_challenges -> users (challenger_uid));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    game_challenges,
+    users,
+);

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -8,7 +8,7 @@ diesel::table! {
         ranked -> Bool,
         public -> Bool,
         tournament_queen_rule -> Bool,
-        expiration_time -> Timestamptz,
+        created_at -> Timestamptz,
     }
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -14,6 +14,7 @@ use crate::db::util::{get_pool, DbPool};
 use actix_web::web;
 use actix_web::{middleware, App, Error, HttpRequest, HttpResponse, HttpServer};
 use actix_web_actors::ws;
+use api::game::challenge;
 use websockets::echo::Echo;
 
 /// WebSocket handshake and start `Echo` actor.
@@ -45,6 +46,9 @@ async fn main() -> std::io::Result<()> {
             ))
             .service(
                 web::scope("/api")
+                    .service(challenge::create_game_challenge)
+                    .service(challenge::accept_game_challenge)
+                    .service(challenge::delete_game_challenge)
                     .service(user::get_user)
                     .service(user::create_user)
                     .service(user::create_guest_user),

--- a/backend/src/model/challenge.rs
+++ b/backend/src/model/challenge.rs
@@ -1,4 +1,4 @@
-use crate::api::game::challenge::NewGameRequest;
+use crate::api::game::challenge::NewChallengeRequest;
 use crate::db::schema::{game_challenges, users};
 use crate::db::util::{get_conn, DbPool};
 use crate::model::user::User;
@@ -7,6 +7,7 @@ use chrono::Days;
 use diesel::prelude::*;
 use diesel::result::Error;
 use diesel_async::RunQueryDsl;
+use uuid::Uuid;
 
 static CHALLENGE_EXPIRATION_LENGTH_IN_DAYS: u64 = 1;
 
@@ -24,7 +25,7 @@ struct NewGameChallenge {
 #[derive(Identifiable, Queryable, Debug)]
 #[diesel(table_name = game_challenges)]
 pub struct GameChallenge {
-    pub id: i32,
+    pub id: Uuid,
     pub challenger_uid: String,
     pub game_type: String,
     pub ranked: bool,
@@ -41,7 +42,7 @@ fn get_expiration_time() -> DateTime<Utc> {
 impl GameChallenge {
     pub async fn create(
         challenger_uid: &str,
-        game: &NewGameRequest,
+        game: &NewChallengeRequest,
         pool: &DbPool,
     ) -> Result<GameChallenge, Error> {
         let conn = &mut get_conn(pool).await?;
@@ -59,7 +60,7 @@ impl GameChallenge {
             .await
     }
 
-    pub async fn get(id: i32, pool: &DbPool) -> Result<GameChallenge, Error> {
+    pub async fn get(id: &Uuid, pool: &DbPool) -> Result<GameChallenge, Error> {
         let conn = &mut get_conn(pool).await?;
         game_challenges::table.find(id).first(conn).await
     }

--- a/backend/src/model/challenge.rs
+++ b/backend/src/model/challenge.rs
@@ -43,7 +43,7 @@ impl GameChallenge {
             game_type: game.game_type.to_string(),
             ranked: game.ranked,
             public: game.public,
-            tournament_queen_rule: true, // This is always true for now
+            tournament_queen_rule: game.tournament_queen_rule,
             created_at: Utc::now(),
         };
         new_challenge

--- a/backend/src/model/challenge.rs
+++ b/backend/src/model/challenge.rs
@@ -3,13 +3,10 @@ use crate::db::schema::{game_challenges, users};
 use crate::db::util::{get_conn, DbPool};
 use crate::model::user::User;
 use chrono::prelude::*;
-use chrono::Days;
 use diesel::prelude::*;
 use diesel::result::Error;
 use diesel_async::RunQueryDsl;
 use uuid::Uuid;
-
-static CHALLENGE_EXPIRATION_LENGTH_IN_DAYS: u64 = 1;
 
 #[derive(Insertable, Debug)]
 #[diesel(table_name = game_challenges)]
@@ -19,7 +16,7 @@ struct NewGameChallenge {
     ranked: bool,
     public: bool,
     tournament_queen_rule: bool,
-    expiration_time: DateTime<Utc>,
+    created_at: DateTime<Utc>,
 }
 
 #[derive(Identifiable, Queryable, Debug)]
@@ -31,12 +28,7 @@ pub struct GameChallenge {
     pub ranked: bool,
     pub public: bool,
     pub tournament_queen_rule: bool,
-    pub expiration_time: DateTime<Utc>, // TODO: periodically cleanup expired challanges
-}
-
-fn get_expiration_time() -> DateTime<Utc> {
-    let duration_until_expired = Days::new(CHALLENGE_EXPIRATION_LENGTH_IN_DAYS);
-    Utc::now() + duration_until_expired
+    pub created_at: DateTime<Utc>, // TODO: periodically cleanup expired challanges
 }
 
 impl GameChallenge {
@@ -52,7 +44,7 @@ impl GameChallenge {
             ranked: game.ranked,
             public: game.public,
             tournament_queen_rule: true, // This is always true for now
-            expiration_time: get_expiration_time(),
+            created_at: Utc::now(),
         };
         new_challenge
             .insert_into(game_challenges::table)

--- a/backend/src/model/challenge.rs
+++ b/backend/src/model/challenge.rs
@@ -1,0 +1,79 @@
+use crate::api::game::challenge::NewGameRequest;
+use crate::db::schema::{game_challenges, users};
+use crate::db::util::{get_conn, DbPool};
+use crate::model::user::User;
+use chrono::prelude::*;
+use chrono::Days;
+use diesel::prelude::*;
+use diesel::result::Error;
+use diesel_async::RunQueryDsl;
+
+static CHALLENGE_EXPIRATION_LENGTH_IN_DAYS: u64 = 1;
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = game_challenges)]
+struct NewGameChallenge {
+    challenger_uid: String,
+    game_type: String,
+    ranked: bool,
+    public: bool,
+    tournament_queen_rule: bool,
+    expiration_time: DateTime<Utc>,
+}
+
+#[derive(Identifiable, Queryable, Debug)]
+#[diesel(table_name = game_challenges)]
+pub struct GameChallenge {
+    pub id: i32,
+    pub challenger_uid: String,
+    pub game_type: String,
+    pub ranked: bool,
+    pub public: bool,
+    pub tournament_queen_rule: bool,
+    pub expiration_time: DateTime<Utc>, // TODO: periodically cleanup expired challanges
+}
+
+fn get_expiration_time() -> DateTime<Utc> {
+    let duration_until_expired = Days::new(CHALLENGE_EXPIRATION_LENGTH_IN_DAYS);
+    Utc::now() + duration_until_expired
+}
+
+impl GameChallenge {
+    pub async fn create(
+        challenger_uid: &str,
+        game: &NewGameRequest,
+        pool: &DbPool,
+    ) -> Result<GameChallenge, Error> {
+        let conn = &mut get_conn(pool).await?;
+        let new_challenge = NewGameChallenge {
+            challenger_uid: challenger_uid.to_string(),
+            game_type: game.game_type.to_string(),
+            ranked: game.ranked,
+            public: game.public,
+            tournament_queen_rule: true, // This is always true for now
+            expiration_time: get_expiration_time(),
+        };
+        new_challenge
+            .insert_into(game_challenges::table)
+            .get_result(conn)
+            .await
+    }
+
+    pub async fn get(id: i32, pool: &DbPool) -> Result<GameChallenge, Error> {
+        let conn = &mut get_conn(pool).await?;
+        game_challenges::table.find(id).first(conn).await
+    }
+
+    pub async fn get_challenger(&self, pool: &DbPool) -> Result<User, Error> {
+        let conn = &mut get_conn(pool).await?;
+        users::table.find(&self.challenger_uid).first(conn).await
+    }
+
+    pub async fn delete(&self, pool: &DbPool) -> Result<(), Error> {
+        let conn = &mut get_conn(pool).await?;
+        diesel::delete(game_challenges::table.find(self.id))
+            .execute(conn)
+            .await?;
+        Ok(())
+    }
+}

--- a/backend/src/model/mod.rs
+++ b/backend/src/model/mod.rs
@@ -1,3 +1,4 @@
+pub mod challenge;
 pub mod game_request;
 pub mod game_response;
 pub mod user;


### PR DESCRIPTION
Sketch implementation of game challenges. The way this works is:

1. User A creates a new game, resulting in a Game Challenge. The challenge encapsulates the proposed game's settings (game type, ranked or not, etc) and can either be public or not. Eventually, public challenges should be listed on the site for any user to join.
2. User A receives a response from the server with a `challenge_url`, which they can send to a friend (User B)
3. User B clicks link (after signing in) and accepts, resulting in the new game actually being created & started

Obviously step 3 depends on us finishing the game API, but curious to hear what people think.