### PR TITLE
will no longer ignore beetle gates when dropping

### DIFF
--- a/js/hive-lib/src/board.ts
+++ b/js/hive-lib/src/board.ts
@@ -141,7 +141,8 @@ export function eachDropDirection(
   return eachDirection((direction) => {
     const neighbor = relativeHexCoordinate(coordinate, direction);
     const neighborStack = getStack(board, neighbor) || [];
-    return stack.length - neighborStack.length >= 2
+    return stack.length - neighborStack.length >= 2 &&
+      !isGated(board, coordinate, direction)
       ? iteratee(neighbor, neighborStack, direction)
       : true;
   });


### PR DESCRIPTION
This was a bug that persisted from lihive where beetles, ladybugs, and pillbugs would ignore beetle gates if it was between being on top of the hive and dropping to the ground. This one line should fix that.