### PR TITLE
Fixes passes and a descend edge case

### DIFF
--- a/engine/src/board.rs
+++ b/engine/src/board.rs
@@ -37,6 +37,7 @@ pub struct Board {
 pub struct MidMoveBoard<'this> {
     pub board: &'this Board,
     pub position_in_flight: Position,
+    pub piece_in_flight: Piece,
 }
 
 impl<'this> MidMoveBoard<'this> {
@@ -313,10 +314,12 @@ impl Board {
                     }
                     for (start_pos, target_positions) in Bug::available_moves(*pos, self) {
                         if let Some(piece) = self.top_piece(start_pos) {
-                            moves
-                                .entry((piece, start_pos))
-                                .or_default()
-                                .append(&mut target_positions.clone());
+                            if !target_positions.is_empty() {
+                                moves
+                                    .entry((piece, start_pos))
+                                    .or_default()
+                                    .append(&mut target_positions.clone());
+                            }
                         }
                     }
                 }

--- a/engine/src/bug.rs
+++ b/engine/src/bug.rs
@@ -218,9 +218,10 @@ impl Bug {
     }
 
     fn descend(position: Position, board: &Board) -> impl Iterator<Item = Position> + '_ {
-        board
-            .positions_available_around(position)
-            .filter(move |pos| !board.gated(board.level(position), position, *pos))
+        position.positions_around().filter(move |pos| {
+            board.level(*pos) < board.level(position)
+                && !board.gated(board.level(position), position, *pos)
+        })
     }
 
     fn ant_moves(position: Position, board: &Board) -> Vec<Position> {
@@ -230,6 +231,7 @@ impl Bug {
         let board = MidMoveBoard {
             position_in_flight: position,
             board,
+            piece_in_flight: board.top_piece(position).unwrap(),
         };
         let mut found_pos = Vec::with_capacity(24);
         let mut unexplored = Vec::with_capacity(24);
@@ -376,6 +378,7 @@ impl Bug {
         let board = MidMoveBoard {
             board,
             position_in_flight: position,
+            piece_in_flight: board.top_piece(position).unwrap(),
         };
         let mut res = Vec::new();
         for pos1 in Bug::crawl_negative_space(position, &board) {

--- a/engine/src/position.rs
+++ b/engine/src/position.rs
@@ -48,7 +48,10 @@ impl Position {
             Self::wrap_around(to.q - self.q),
             Self::wrap_around(to.r - self.r),
         );
-        matches!(diff, (0, -1) | (0, 1) | (1, -1) | (-1, 1) | (-1, 0) | (1, 0))
+        matches!(
+            diff,
+            (0, -1) | (0, 1) | (1, -1) | (-1, 1) | (-1, 0) | (1, 0)
+        )
     }
 
     // this implements "odd-r horizontal" which offsets odd rows to the right

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -69,12 +69,12 @@ impl State {
         piece: &str,
         position: &str,
     ) -> Result<(), GameError> {
-        // println!("{piece} {position}");
         match piece {
             "pass" => {
                 if self.board.moves(self.turn_color).is_empty() {
                     self.pass();
                 } else {
+                    println!("Moves are: {:?}", self.board.moves(self.turn_color));
                     return Err(GameError::InvalidMove {
                         piece: "NA".to_string(),
                         from: "NA".to_string(),
@@ -117,6 +117,7 @@ impl State {
     }
 
     fn next_turn(&mut self) {
+        self.game_status = GameStatus::InProgress;
         match self.board.game_result() {
             GameResult::Winner(color) => {
                 self.game_status = GameStatus::Finished(GameResult::Winner(color));
@@ -156,6 +157,7 @@ impl State {
             .board
             .is_valid_move(self.turn_color, piece, current_position, target_position)
         {
+            println!("Board state is: {}", self.board);
             err.update_reason("This move isn't valid.");
             return Err(err);
         }
@@ -198,6 +200,7 @@ impl State {
     }
 
     pub fn play_turn(&mut self, piece: Piece, target_position: Position) -> Result<(), GameError> {
+        // TODO check for GameStatus::Finished
         if self.board.piece_already_played(piece) {
             self.turn_move(piece, target_position)?
         } else {

--- a/engine/test_pgns/valid/descend.pgn
+++ b/engine/test_pgns/valid/descend.pgn
@@ -1,0 +1,109 @@
+[GameType "Base+MLP"]
+[Date "2023.02.07"]
+[Event ""]
+[Site "boardspace.net"]
+[Round ""]
+[White "Kaur50"]
+[Black "MikhailTal"]
+[Result "1-0"]
+
+1. wL
+2. bL /wL
+3. wA1 wL/
+4. bM /bL
+5. wQ wL-
+6. bP \bM
+7. wA1 -bM
+8. bQ bL\
+9. wM \wQ
+10. bB1 /bQ
+11. wB1 -wA1
+12. bP wA1\
+13. wA2 \wL
+14. bA1 bQ\
+15. wM bA1\
+16. bB1 bQ
+17. wB1 wA1
+18. bB1 bL
+19. wB1 bP
+20. bB1 wL
+21. wP wQ-
+22. bB1 wQ
+23. wS1 wP\
+24. bB1 wP
+25. wA3 /wS1
+26. bG1 bB1/
+27. wA3 bQ-
+28. bG2 bG1-
+29. wA2 \bG1
+30. bG2 wQ/
+31. wB2 /wM
+32. bG1 \wQ
+33. wB2 /bA1
+34. bG3 \bG1
+35. wB2 bA1
+36. bG3 wQ\
+37. wL -bG1
+38. bL /wQ
+39. wB2 bQ
+40. bL -wQ
+41. wB2 bM
+42. bL /wQ
+43. wA3 bA1-
+44. bB1 wQ
+45. wP bG2-
+46. bB1 wL\
+47. wS2 wP\
+48. bB1 wL
+49. wB2 bQ
+50. bA2 /bB1
+51. wB2 bL
+52. bG2 wB1-
+53. wB1 bM
+54. bG2 wA3-
+55. wM /bQ
+56. bA3 \bA2
+57. wM bP
+58. bS1 /bA1
+59. wG1 wS2\
+60. bA3 wG1-
+61. wG2 -wM
+62. bB2 \bG1
+63. wG2 /bQ
+64. bB2 bG1
+65. wA1 \bA3
+66. bA3 wG1\
+67. wA2 bA3/
+68. bB2 -wQ
+69. wQ bG3/
+70. bS1 -wM
+71. wQ wP/
+72. bA3 wB2/
+73. wG1 \bQ
+74. bB2 wB2
+75. wA2 bG1-
+76. bG1 /wS1
+77. wA3 bA1\
+78. bA3 -wA3
+79. wB1 bQ
+80. bM wB1
+81. wA1 /bA3
+82. bA1 wA3/
+83. wM wG2
+84. bS1 \bP
+85. wA2 bG2-
+86. bS2 bB1-
+87. wQ wP-
+88. bB1 bA2
+89. wP bG3/
+90. bB1 wG1
+91. wM bM\
+92. bG3 -bB1
+93. wG3 /wA1
+94. bB1 bM
+95. wG3 \bA1
+96. bB1 wM
+97. wA2 bG2\
+98. bS1 \wA1
+99. wG2 /bS1
+100. bM wG3

--- a/engine/test_pgns/valid/pass2.pgn
+++ b/engine/test_pgns/valid/pass2.pgn
@@ -1,0 +1,57 @@
+[GameType "Base"]
+[Date "2023.03.16"]
+[Event ""]
+[Site "boardspace.net"]
+[Round ""]
+[White "Goozi"]
+[Black "Dumbot"]
+[Result "0-1"]
+
+1. wS1
+2. bG1 /wS1
+3. wS2 wS1-
+4. bS1 -bG1
+5. wQ wS2/
+6. bQ -bS1
+7. wA1 \wS1
+8. bG2 bG1\
+9. wA1 \bQ
+10. bB1 -bG2
+11. wB1 -wQ
+12. bB2 bG2-
+13. wS2 bB2-
+14. bA1 /bB2
+15. wG1 \wA1
+16. bS2 -bA1
+17. wG1 bQ\
+18. bS1 \wB1
+19. wB2 wA1/
+20. bA1 \wB2
+21. wG2 -wA1
+22. bS2 wS2\
+23. wG2 bQ/
+24. bA2 -bS1
+25. wA2 -wA1
+26. bA2 wQ\
+27. wA2 -bQ
+28. bS1 wQ-
+29. wG3 /wG1
+30. bA3 /bB2
+31. wA3 -wA2
+32. bA3 \wA3
+33. wG2 /bQ
+34. bQ wB2\
+35. wG3 bQ\
+36. bQ wB2-
+37. wG3 /bG2
+38. bA1 wQ/
+39. wG3 \bB1
+40. bB1 bG1
+41. pass
+42. bG3 bA1-
+43. pass
+44. bG3 \wQ
+45. pass
+46. bB1 wS1
+47. pass
+48. bB1 /wQ


### PR DESCRIPTION
@IongIer created a new set of 3995 pgns (all games played on BS this year) and found two edge cases with it, one where passes don't get handled correctly and one weird beetle descend issue. We fixed the two issues and added 2 new test_pgns. `cargo test` & `clippy` are happy, too. 
