### PR TITLE
Changes reserve to a Hashmap<Bugs, Vec<(unplayed)Piece>>

### DIFF
--- a/backend/src/api/game/game_state_response.rs
+++ b/backend/src/api/game/game_state_response.rs
@@ -4,8 +4,8 @@ use crate::{
     server_error::ServerError,
 };
 use hive_lib::{
-    bug::Bug, game_control::GameControl, game_status::GameStatus, game_type::GameType,
-    history::History, piece::Piece, position::Position, state::State, color::Color,
+    bug::Bug, color::Color, game_control::GameControl, game_status::GameStatus,
+    game_type::GameType, history::History, piece::Piece, position::Position, state::State,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -13,7 +13,7 @@ use std::{collections::HashMap, str::FromStr};
 
 #[serde_as]
 #[serde_with::skip_serializing_none]
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct GameStateResponse {
     pub game_id: i32,
     pub turn: usize,
@@ -25,8 +25,8 @@ pub struct GameStateResponse {
     #[serde_as(as = "Vec<(_, _)>")]
     pub moves: HashMap<String, Vec<Position>>,
     pub spawns: Vec<Position>,
-    pub reserve_black: HashMap<Bug, i8>,
-    pub reserve_white: HashMap<Bug, i8>,
+    pub reserve_black: HashMap<Bug, Vec<String>>,
+    pub reserve_white: HashMap<Bug, Vec<String>>,
     pub history: Vec<(String, String)>,
     pub game_control_history: Vec<(i32, GameControl)>,
 }

--- a/backend/src/db/schema.rs
+++ b/backend/src/db/schema.rs
@@ -48,9 +48,4 @@ diesel::joinable!(game_challenges -> users (challenger_uid));
 diesel::joinable!(games_users -> games (game_id));
 diesel::joinable!(games_users -> users (user_uid));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    game_challenges,
-    games,
-    games_users,
-    users,
-);
+diesel::allow_tables_to_appear_in_same_query!(game_challenges, games, games_users, users,);


### PR DESCRIPTION
This changes `reserve_w/b` from `Hashmap<Bug, i8>` to the following:
```rs 
game: GameStateResponse { ..., 
  reserve_black: {Ant: ["bA2", "bA3"], Grasshopper: ["bG1", "bG2", "bG3"], Mosquito: ["bM"], Spider: ["bS1", "bS2"], Beetle: ["bB1", "bB2"]}, 
  reserve_white: {Spider: ["wS1", "wS2"], Grasshopper: ["wG1", "wG2", "wG3"], Beetle: ["wB2"], Pillbug: ["wP"], Ant: ["wA2", "wA3"]}, 
  history: [("wL", "."), ("bL", "/wL"), ("wM", "wL/"), ("bQ", "bL\\"), ("wQ", "\\wL"), ("bP", "bQ\\"), ("wA1", "wM\\"), ("bA1", "-bL"), ("wM", "/bQ"), ("bA1", "\\wQ"), ("wB1", "/wM")]
}
```